### PR TITLE
ブログタイトルの文字サイズを大きく変更

### DIFF
--- a/app/routes/_renderer.tsx
+++ b/app/routes/_renderer.tsx
@@ -17,7 +17,7 @@ export default jsxRenderer(({ children, title }) => {
 					<nav>
 						<ul>
 							<li>
-								<strong>
+								<strong class="text-3xl">
 									<a href="/">nanaket-workers-blog</a>
 								</strong>
 							</li>

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -23,7 +23,7 @@ export default createRoute(async (c) => {
 			{postsList.map((post) => (
 				<article key={post.id}>
 					<hgroup>
-						<h2>
+						<h2 class="text-4xl">
 							<a href={`/posts/${post.slug}`}>{post.title}</a>
 						</h2>
 						{post.publishedAt && (

--- a/app/routes/posts/[slug].tsx
+++ b/app/routes/posts/[slug].tsx
@@ -45,7 +45,7 @@ export default createRoute(async (c) => {
 
 			<article>
 				<header>
-					<h1>{post.title}</h1>
+					<h1 class="text-5xl">{post.title}</h1>
 					{post.publishedAt && (
 						<p>
 							<time>


### PR DESCRIPTION
- 個別投稿ページのh1タイトルにtext-5xlクラスを追加
- 記事一覧ページのh2タイトルにtext-4xlクラスを追加